### PR TITLE
Update stringSolutions.js - String-1 -- firstHalf

### DIFF
--- a/src/data/stringSolutions.js
+++ b/src/data/stringSolutions.js
@@ -44,7 +44,7 @@ solutions.nonStart = function (a, b) {
 
 solutions.firstHalf = function (str) {
   if (str.length % 2 == 0) {
-    return str.substring(0, str.length);
+    return str.substring(0, str.length / 2);
   }
   return str;
 };


### PR DESCRIPTION
There was a bug that was fixed. To pass this test all that is needed is to return str, instead of the actual function needed to pass it.
![String1-firstHalf](https://user-images.githubusercontent.com/91473674/182049990-5568fa8e-e6b8-4024-be92-7bbcf37b0e9e.PNG)


