### PR TITLE
Add check on "smallsNeeded" in makeChocolate solution.

### DIFF
--- a/src/data/logicSolutions.js
+++ b/src/data/logicSolutions.js
@@ -408,7 +408,10 @@ solutions.cigarParty = function (cigars, isWeekend) {
     const bigsUsed = Math.min(big, bigsNeeded);
      // how many leftover
     const smallsNeeded = goal - bigsUsed * 5;
-  
+    
+    if (smallsNeeded > small) {
+        return -1;
+    }
     return smallsNeeded;
   };
   


### PR DESCRIPTION
Original solution did not check if smallsNeeded was greater than the number of small bars. This causes the test case of makeChocolate(1, 2, 7) to return an incorrect solution of 2 small bars needed.